### PR TITLE
fix(): bump spring-web and httpclient5

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -41,10 +41,10 @@
     <netty.codec.http.version>4.1.115.Final</netty.codec.http.version>
     <netty.codec.http2.version>4.1.115.Final</netty.codec.http2.version>
     <netty.transport.native.epoll.version>4.1.115.Final</netty.transport.native.epoll.version>
-    <httpclient5.version>5.4.1</httpclient5.version>
+    <httpclient5.version>5.4.3</httpclient5.version>
     <xerces.version>2.12.2</xerces.version>
     <commons.codec.version>1.17.1</commons.codec.version>
-    <spring.web.version>6.2.0</spring.web.version>
+    <spring.web.version>6.2.8</spring.web.version>
     <freemarker.version>2.3.33</freemarker.version>
     <gson.version>2.11.0</gson.version>
     <rest-assured.version>5.5.0</rest-assured.version>


### PR DESCRIPTION
#### 📲 What

Bumps spring-web and httpclien5 with minor fixes.

#### 🤔 Why

As part of our responsibilities under ISO27001, we are required to manage and mitigate risks associated with software vulnerabilities. By enforcing a secure version of webpack-dev-server, we reduce the risk of known vulnerabilities being exploited in our development environment. This proactive approach to dependency management demonstrates our commitment to maintaining the confidentiality, integrity, and availability of our information assets, as required by ISO27001 controls on software development and vulnerability management.

#### 🛠 How

Manual update to `pom.xml` then clean, build and test.

#### 👀 Evidence

```
[INFO] Results:
[INFO]
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
```

```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2025-06-27T11:48:30+01:00
[INFO] ------------------------------------------------------------------------
```

#### 🕵️ How to test

```
git clean -dfx
cd java
./mvnw clean install test -Plocal
```

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
