### PR TITLE
chore(): bump VM image from 20.04 → 24.04 and OWASP Dependency Check to 12.1.3

### DIFF
--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -53,7 +53,7 @@
 
     <!-- Maven plugins -->
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
-    <owasp-dependency-check-plugin.version>11.1.0</owasp-dependency-check-plugin.version>
+    <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
     <fmt-maven-plugin.version>2.13</fmt-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>

--- a/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-javaspring-k8s.yml
@@ -118,7 +118,7 @@ variables:
 
   # DEFAULT IMAGE RUNNER
   - name: pool_vm_image
-    value: ubuntu-20.04
+    value: ubuntu-24.04
 
   # Maven
   - name: maven_cache_directory

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <spring.cloud.dependencies.version>2022.0.4</spring.cloud.dependencies.version>
     <pact.version>3.5.24</pact.version>
     <spring.data.commons>3.4.0</spring.data.commons>
-    <owasp-dependency-check-plugin.version>11.1.0</owasp-dependency-check-plugin.version>
+    <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
     <junit-jupiter.version>5.11.3</junit-jupiter.version>
 
     <!-- Set 'pact.broker.url' and 'pact.broker.token' -->


### PR DESCRIPTION
#### 📲 What

1. Bump VM image from 20.04 → 24.04
2. Bump OWASP Dependency Check to [12.1.3](https://mvnrepository.com/artifact/org.owasp/dependency-check-maven/12.1.3)

#### 🤔 Why

Ubuntu 20.04 is no longer available.

#### 🛠 How

Changed core var referenced elsewhere.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
